### PR TITLE
fix: repair API version auto-discovery regex to match server error format

### DIFF
--- a/app/static/js/api-client.js
+++ b/app/static/js/api-client.js
@@ -186,7 +186,7 @@ export class ApiClient {
   }
 
   extractApiVersion(message) {
-    const match = String(message || "").match(/Expected:\s*([^,\s]+)/i);
+    const match = String(message || "").match(/Expected(?:\s+one\s+of)?:\s*([^,\s]+)/i);
     return match ? normalizeApiVersion(match[1]) : null;
   }
 }

--- a/app/static/js/shared.js
+++ b/app/static/js/shared.js
@@ -9,7 +9,7 @@ export const SEARCH_RESULT_LIMIT = 100;
 export const DEFAULT_VIEWER_CONFIG = Object.freeze({
   bymBaseUrl: "http://localhost:3001",
   cdnBaseUrl: "http://localhost:3001",
-  apiVersion: "v1.5.4-beta",
+  apiVersion: "v1.6.2-beta",
 });
 export const STABLE_VIEWER_CONFIG = Object.freeze({
   bymBaseUrl: "https://server.bymrefitted.com",


### PR DESCRIPTION
Server changed response to 
  Invalid API version. Expected one of: v1.6.2-beta, v1.0.0-beta, Received: {{viewer_probe}}
instead of just 
  Invalid API version. Expected: ...

This fix updates the regex to address this update. It also changes the hardcoded backup version to the current most recent value. 
